### PR TITLE
chore: fix missing space before `{` in TOML parsing regex

### DIFF
--- a/scripts/bump_versions.sh
+++ b/scripts/bump_versions.sh
@@ -24,7 +24,7 @@ find . -name "Cargo.toml" | while read -r cargo_file; do
   name=""
   while IFS= read -r line; do
     # 1) Match workspace deps like: alto-foo = { version = "0.0.3", path = "foo" }
-    if [[ "${line}" =~ ^[[:space:]]*(alto-[^[:space:]]+)[[:space:]]*=\ {[[:space:]]*version[[:space:]]*=[[:space:]]*\"([0-9]+\.[0-9]+\.[0-9]+)\" ]]; then
+    if [[ "${line}" =~ ^[[:space:]]*(alto-[^[:space:]]+)[[:space:]]*=[[:space:]]*\{[[:space:]]*version[[:space:]]*=[[:space:]]*\"([0-9]+\.[0-9]+\.[0-9]+)\" ]]; then
       old="${BASH_REMATCH[2]}"
       new="$(bump_version "${old}")"
       line="${line/${old}/${new}}"


### PR DESCRIPTION
The regular expression for matching workspace dependencies in `Cargo.toml` was missing a required space before `{`.
In TOML, `=` must be surrounded by spaces, so I fixed the regex to ensure correct parsing.  
