### PR TITLE
chore(simulator): add health endpoint and permissive cors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3370,6 +3371,20 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ clap = "4.5.18"
 tokio = "1.41.0"
 axum = "0.7.9"
 tower = "0.5.2"
+tower-http = "0.6.2"
 reqwest = "0.12.12"
 tokio-tungstenite = "0.24.0"
 

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -22,6 +22,7 @@ clap = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["full"] }
 axum = { workspace = true, features = ["ws"] }
 tower = { workspace = true }
+tower-http = { workspace = true, features = ["cors"] }
 reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 tokio-tungstenite = { workspace = true }
 

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -17,6 +17,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 use tokio::sync::broadcast;
+use tower_http::cors::CorsLayer;
 
 const LATEST: &str = "latest";
 
@@ -219,6 +220,7 @@ impl Api {
 
     pub fn router(&self) -> Router {
         Router::new()
+            .route("/health", get(health_check))
             .route("/seed", post(seed_upload))
             .route("/seed/:query", get(seed_get))
             .route("/notarization", post(notarization_upload))
@@ -227,8 +229,13 @@ impl Api {
             .route("/finalization/:query", get(finalization_get))
             .route("/block/:query", get(block_get))
             .route("/consensus/ws", get(consensus_ws))
+            .layer(CorsLayer::permissive())
             .with_state(self.simulator.clone())
     }
+}
+
+async fn health_check() -> impl IntoResponse {
+    (StatusCode::OK, "ok")
 }
 
 async fn seed_upload(


### PR DESCRIPTION
### What
- adds `/health` endpoint
- adds permissive cors

### Why
Required for local testing with the `explorer`. Without these, the explorer fails to load blocks and gets stuck on the loading.

| Before | After |
|--------|--------|
| <img width="1102" height="957" alt="image" src="https://github.com/user-attachments/assets/1fdfab69-2d99-4062-827b-629c5ca3d059" /> | <img width="1728" height="957" alt="image" src="https://github.com/user-attachments/assets/a5b3036d-46c8-42f8-a0f9-0d6caba07a8b" /> | 