### PR TITLE
fix: backfill test

### DIFF
--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -404,7 +404,7 @@ mod tests {
                 let metrics = context.encode();
 
                 // Iterate over all lines
-                let mut success = true;
+                let mut success = false;
                 for line in metrics.lines() {
                     // Ensure it is a metrics line
                     if !line.starts_with("validator-") {


### PR DESCRIPTION
Fixes the backfill test - it previously was not waiting for the first set of validators to process `initial_container_required` blocks.

(It still passes thankfully.)